### PR TITLE
Support different mp3 file lengths.

### DIFF
--- a/src/chapters.ts
+++ b/src/chapters.ts
@@ -1,19 +1,31 @@
 import * as fs from "fs";
 import { parse } from "csv-parse";
-import { finished } from"stream/promises";
+import { finished } from "stream/promises";
 import { Chapter, Context, Timing } from "./context";
 import { exec } from "./exec";
 
+function pad(num: number, size: number): string {
+  let s = num + "";
+  while (s.length < size) s = "0" + s;
+  return s;
+}
+
 export function fid(id: number): string {
-  return `${"0".repeat(3 - id.toString().length)}${id}`;
+  return pad(id, 3);
 }
 
 function getSourceAudio(context: Context, chapterId: number): string {
-  const file = `resource/${context.book}/audio/${fid(chapterId)}.mp3`;
-  if (!fs.existsSync(file)) {
-    throw new Error(`File ${file} not found`);
+  // Try to find audio file with 1, 2 or 3 digits as it's common for audio files to have
+  // xx.mp3 or xxx.mp3 formats.
+  for (let i = 1; i <= 3; i++) {
+    const paddedChapter = pad(chapterId, i);
+    const file = `resource/${context.book}/audio/${paddedChapter}.mp3`;
+    if (fs.existsSync(file)) {
+      return file;
+    }
   }
-  return file;
+  throw new Error(
+    `Audio file for chapter ${chapterId} not found in resource/${context.book}/audio/`);
 }
 
 function getGeneratedVideoFile(context: Context, chapterId: number): string {
@@ -24,11 +36,11 @@ async function getTimings(audioFiles: string[]): Promise<Timing[]> {
   console.log('\nGetting audio files lengths:');
   const durations: string[] = await Promise.all(
     audioFiles.map((file) => {
-        return exec(
-          `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 ${file}`
-        );
-      })
-    );
+      return exec(
+        `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 ${file}`
+      );
+    })
+  );
   let startTime = 0;
   return durations.map((v) => {
     const duration = parseFloat(v);
@@ -78,6 +90,7 @@ export async function getChapters(context: Context): Promise<Chapter[]> {
       sourceAudioFile: audioFiles[ind],
       timing: timings[ind],
       generatedVideoFile: getGeneratedVideoFile(context, id),
-  }});
+    }
+  });
 }
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,9 +1,9 @@
 
-import {beforeEach, describe, expect, it} from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as cp from 'child_process';
-import {exec} from './exec';
+import { exec } from './exec';
 import { Config } from './context';
 import * as yaml from 'yaml';
 
@@ -33,9 +33,14 @@ function assertOutputOfCreateTimecodesMatches(output: string) {
  */
 function updateConfig(book: string, updateFn: (config: Config) => Config) {
     const configFile = `resource/${book}/config.yml`;
-    const config: Config = yaml.parse(fs.readFileSync(configFile, {encoding: 'utf8'}));
+    const config: Config = yaml.parse(fs.readFileSync(configFile, { encoding: 'utf8' }));
     const updatedConfig = updateFn(config);
     fs.writeFileSync(configFile, yaml.stringify(updatedConfig));
+}
+
+function expectBetween(value: number, min: number, max: number) {
+    expect(value).toBeGreaterThanOrEqual(min);
+    expect(value).toBeLessThanOrEqual(max);
 }
 
 
@@ -48,7 +53,7 @@ describe('integration', () => {
     // of total mp3 files duration.
     it('sample book generated', async () => {
         const options: cp.ExecOptions = {
-            env: {...process.env, 'BOOK': TEST_BOOK},
+            env: { ...process.env, 'BOOK': TEST_BOOK },
         };
         const commands = [
             'add-book.ts',
@@ -65,19 +70,19 @@ describe('integration', () => {
         assertOutputOfCreateTimecodesMatches(results[results.length - 1]);
         const videoLength = await getDurationSec(path.join(OUT_DIR, 'output.mp4'));
         // There are two mp3 files, each roughly 5s. Total 11.2s.
-        expect(videoLength).toBeCloseTo(11.2, 0);
+        expectBetween(videoLength, 11.2, 12);
     }, /* timeout= */ 60_000);
 
     it('preview mode is working', async () => {
         const options = {
-            env: {...process.env, 'BOOK': TEST_BOOK},
+            env: { ...process.env, 'BOOK': TEST_BOOK },
             encoding: 'utf8',
         };
         await exec(`./add-book.ts`, options);
 
         // Enable preview_covers.
         updateConfig(TEST_BOOK, (config) => {
-            return {...config, preview_covers: true};
+            return { ...config, preview_covers: true };
         });
 
         await exec(`./generate-chapters.ts`, options);
@@ -85,7 +90,24 @@ describe('integration', () => {
         const videoLength = await getDurationSec(path.join(OUT_DIR, 'output.mp4'));
         // When preview is enabled each chapter should be generated from a 1sec file,
         // so total length is 2sec.
-        expect(videoLength).toBeCloseTo(2, 1);
+        expectBetween(videoLength, 2, 2.5);
 
-    }, /* timeout= */ 60_000)
+    }, /* timeout= */ 60_000);
+
+    it('different length filenames are supported', async () => {
+        const options: cp.ExecOptions = {
+            env: { ...process.env, 'BOOK': TEST_BOOK },
+        };
+        await exec(`./add-book.ts`, options);
+
+        await fs.move(`${RESOURCES_DIR}/audio/000.mp3`, `${RESOURCES_DIR}/audio/0.mp3`);
+        await fs.move(`${RESOURCES_DIR}/audio/001.mp3`, `${RESOURCES_DIR}/audio/01.mp3`);
+
+        await exec(`./generate-chapters.ts`, options);
+        const chapter0Length = await getDurationSec(path.join(OUT_DIR, 'chapters/000.mp4'));
+        expectBetween(chapter0Length, 5.5, 6);
+        const chapter1Length = await getDurationSec(path.join(OUT_DIR, 'chapters/001.mp4'));
+        expectBetween(chapter1Length, 5.5, 6);
+
+    }, /* timeout= */ 60_000);
 });


### PR DESCRIPTION
Currently the tool expects all files to have exactly 3 digits: 001.mp3, 002.mp3. But often audio files use 2 digits or even 1.

With this change the tool will try to use different lengths for each chapter: 2.mp3, 02.mp3 and 002.mp3 until it finds a file.